### PR TITLE
Enable cooldown stance on burst-mode guns

### DIFF
--- a/items/active/weapons/ranged/knightfall_gunfire.lua
+++ b/items/active/weapons/ranged/knightfall_gunfire.lua
@@ -1,0 +1,8 @@
+require "/items/active/weapons/ranged/gunfire.lua"
+
+-- Overrides default gunfire burst function to include cooldown
+local baseBurst = GunFire.burst
+function GunFire:burst()
+  baseBurst(self)
+  self:setState(self.cooldown)
+end

--- a/items/active/weapons/ranged/shotgun/knightfall_pulverizer/knightfall_pulverizer.activeitem
+++ b/items/active/weapons/ranged/shotgun/knightfall_pulverizer/knightfall_pulverizer.activeitem
@@ -48,7 +48,7 @@
 	"elementalType": "fire",
 	
 	"primaryAbility": {
-		"scripts": ["/items/active/weapons/ranged/gunfire.lua"],
+		"scripts": ["/items/active/weapons/ranged/knightfall_gunfire.lua"],
 		"class": "GunFire",
 
 		"fireTime": 1.2,


### PR DESCRIPTION
Enable cooldown stance on burst-mode guns using an extended script `knightfall_gunfire.lua`.