### PR TITLE
Update Pixelmaker and Lifesteal augments

### DIFF
--- a/items/augments/back/knightfall_lifesteal_augment.augment
+++ b/items/augments/back/knightfall_lifesteal_augment.augment
@@ -5,12 +5,12 @@
   "tooltipKind" : "eppaugment",
   "category" : "eppAugment",
   "inventoryIcon" : "knightfall_lifesteal_augment.png",
-  "description" : "An EPP Module that heals for 45 health on your next attack. Has a 5 second cooldown.",
+  "description" : "An EPP Module that heals for 8% of max health on your next attack. Has a 5 second cooldown.",
   "shortdescription" : "Lifesteal Augment",
 
   "augment" : {
     "type" : "back",
-    "name" : "lifesteal",
+    "name" : "kflifesteal",
     "displayName" : "Lifesteal",
     "displayIcon" : "/items/augments/back/knightfall_lifesteal_augment.png",
     "effects" : [ "knightfall_lifesteal" ]

--- a/items/augments/back/knightfall_pixelmaker_augment.augment
+++ b/items/augments/back/knightfall_pixelmaker_augment.augment
@@ -10,7 +10,7 @@
 
   "augment" : {
     "type" : "back",
-    "name" : "pixelmaker",
+    "name" : "kfpixelmaker",
     "displayName" : "Pixelmaker",
     "displayIcon" : "/items/augments/back/knightfall_pixelmaker_augment.png",
     "effects" : [ "knightfall_pixelmaker" ]

--- a/stats/effects/knightfall_augments/knightfall_lifesteal.lua
+++ b/stats/effects/knightfall_augments/knightfall_lifesteal.lua
@@ -1,34 +1,71 @@
 require "/scripts/util.lua"
 require "/scripts/status.lua"
 
+--[[--
+  * knightfall_lifesteal.lua
+  * Augment status effect
+  *
+  * Attacks (beyond a damage threshold) will heal the entity for a flat amount or
+  * a percentage of max health. The damage is accumulated and lifesteal triggers
+  * once the amount goes over damageThres. 'Orbs' will fly towards the entity, but
+  * these are only for visual effect and would not heal (health is added instantly)
+  *
+  * Created by Lyrthras#7199 on 08/28/20
+  * v1.1 [09/02/20] - added percentage mode, check if hit entity is an
+  *                   enemy, cooldown on init to prevent re-equipping
+  *                   exploit, added damageThres and maxProjs parameter
+--]]--
+
+--[[--
+  === JSON fields ( * = required, - = optional ) ===
+  [ Mechanics ]
+  - cooldown    - float:  [def 5] seconds between lifesteals. (Damage is not accumulated on cooldown)
+  - stealAmount - float:  [def 10] isPercent=false: flat amount to heal; isPercent=true: percentage of maximum health to heal.
+  - isPercent   - bool:   [def false] false if stealAmount is a flat value, true if it's a percentage.
+  - damageThres - int:    [def 25] lifesteal triggers when accumulated damage goes above this value.
+  - gracePeriod - float:  [def cooldown or 3] seconds without inflicting damage before accumulated damage resets.
+
+  [ Visual ]
+  - flashColor  - string: [def "000000"] color (in hex) of the visual blink on the entity.
+  - flashValue  - float:  [def 0] value between 0 and 1, how the flash color should mix. 1 would make the entity solid-color, 0 disables it.
+  - flashTime   - float:  [def 1] how long the flash effect would last.
+  - maxProjs    - int:    [def 5] how many orbs would spawn on lifesteal. 0 to disable.
+--]]--
+
 function init()
+  script.setUpdateDelta(6)
   animator.setParticleEmitterOffsetRegion("lifesteal", mcontroller.boundBox())
 
-  script.setUpdateDelta(6)
-
-  self.flashColor = config.getParameter("flashColor")
+  self.flashColor = config.getParameter("flashColor") or "000000"
   self.flashValue = config.getParameter("flashValue") or 0
   self.colorTime = config.getParameter("flashTime") or 1
-  self.cooldown = config.getParameter("cooldown") or 3
+  self.cooldown = config.getParameter("cooldown") or 5
   self.gracePeriod = config.getParameter("gracePeriod") or self.cooldown or 3
-  self.lifestealAmount = config.getParameter("stealAmount") or 25
+  self.damageThres = config.getParameter("damageThres") or 25
+  self.lifestealAmount = config.getParameter("stealAmount") or 10
+  self.isPercent = config.getParameter("isPercent")  -- default nil/false
+  self.maxProjectiles = config.getParameter("maxProjs") or 5
 
-  self.healPerProj = 5
-
-  self.cooldownTimer = 0
+  self.cooldownTimer = self.cooldown
   self.graceTimer = -255
-  self.colorTimer = 0
+  self.colorTimer = -255
 
   self.totalDmg = 0
+end
+
+function isEnemy(notif)
+  local selfTeam = entity.damageTeam()
+  local otherTeam = world.entityDamageTeam(notif.targetEntityId)
+  return otherTeam and selfTeam.team ~= otherTeam.team and otherTeam.type == "enemy"
 end
 
 function updateDamage(notifications)
   if self.cooldownTimer > 0 then return end
   for _, n in pairs(notifications) do
-    if n.hitType == "Hit" then
+    if n.hitType == "Hit" and isEnemy(n) then
       self.graceTimer = self.gracePeriod
-      self.totalDmg = self.totalDmg + n.damageDealt
-      if self.totalDmg >= self.lifestealAmount then
+      self.totalDmg = self.totalDmg + n.healthLost
+      if self.totalDmg >= self.damageThres then
         triggerLifesteal(n)
         break
       end
@@ -40,20 +77,24 @@ function triggerLifesteal(notif)
   self.totalDmg = 0
   self.graceTimer = -255
 
-  local added = status.giveResource("health", self.lifestealAmount)
+  local amount = self.isPercent and
+      status.resourceMax("health") * self.lifestealAmount / 100 or
+      self.lifestealAmount
+
+  local healed = status.giveResource("health", amount) / amount
 
   animator.burstParticleEmitter("lifesteal")
-  status.addEphemeralEffect("knightfall_lifestolen", added / self.lifestealAmount)
-  createProjectiles(notif, added)
+  status.addEphemeralEffect("knightfall_lifestolen", healed)
+  createProjectiles(notif, healed)
 
   self.cooldownTimer = self.cooldown
-  self.colorTimer = self.colorTime * (added / self.lifestealAmount)
+  self.colorTimer = self.colorTime * healed
 end
 
-function createProjectiles(notif, dmg)
-  -- local from = notif.targetEntityId
+function createProjectiles(notif, healed)
+  if self.maxProjectiles < 1 then return end
   local pos = notif.position
-  local count = math.ceil(dmg / self.healPerProj)
+  local count = math.ceil(healed * self.maxProjectiles)
   for _= 1, count do
     local randVel = {-5 + math.random() * 10, -5 + math.random() * 10}
     world.spawnProjectile(
@@ -72,18 +113,17 @@ function update(dt)
     self.colorTimer = self.colorTimer - dt
     local val = self.flashValue * (self.colorTimer / self.colorTime)
     effect.setParentDirectives("fade=" .. self.flashColor .. "=" .. val)
-  else
+  elseif self.colorTimer > -255 then
     effect.setParentDirectives("fade=" .. self.flashColor .."=0")
+    self.colorTimer = -255
   end
 
-  if self.graceTimer > -255 then
-    if self.graceTimer <= 0 then
-      -- reset accumulated damage
-      self.totalDmg = 0
-      self.graceTimer = -255
-    else
-      self.graceTimer = self.graceTimer - dt
-    end
+  if self.graceTimer > 0 then
+    self.graceTimer = self.graceTimer - dt
+  elseif self.graceTimer > -255 then
+    -- reset accumulated damage
+    self.totalDmg = 0
+    self.graceTimer = -255
   end
 
   if self.cooldownTimer > 0 then
@@ -95,8 +135,4 @@ function update(dt)
   else
     self.hitListener = damageListener("inflictedDamage", updateDamage)
   end
-end
-
-function onExpire()
-
 end

--- a/stats/effects/knightfall_augments/knightfall_lifesteal.statuseffect
+++ b/stats/effects/knightfall_augments/knightfall_lifesteal.statuseffect
@@ -7,7 +7,9 @@
     "flashValue" : 0.2,
     "flashColor" : "30FF30",
     "gracePeriod": 5,
-    "stealAmount": 45
+    "damageThres": 15,
+    "stealAmount": 8,
+    "isPercent"  : true
   },
   "defaultDuration" : 1,
 

--- a/stats/effects/knightfall_augments/knightfall_pixelmaker.lua
+++ b/stats/effects/knightfall_augments/knightfall_pixelmaker.lua
@@ -1,21 +1,47 @@
 require "/scripts/util.lua"
 require "/scripts/status.lua"
 
+--[[--
+  * knightfall_pixelmaker.lua
+  * Augment status effect
+  *
+  * Attacks (beyond a damage threshold) will give the entity an amount of pixels.
+  *
+  * Created by Lyrthras#7199 on 08/29/20
+  * v1.1 [09/02/20] - check if attacked entity is an enemy, fixed
+  *                   bug where pickupDelay parameter was ignored.
+--]]--
+
+--[[--
+  === JSON fields ( * = required, - = optional ) ===
+  - damageThres - int:   [def 10] Accumulated damage above this will grant pixelAmount pixels.
+  - pixelAmount - int:   [def 1] amount of pixels to grant per damageThres damage.
+  - pickupDelay - float: [def 0] delay in seconds before the spawned pixels can be collected.
+  - onMonster   - bool:  [def false] spawn the pixels on the monster attacked instead.
+--]]--
+
 function init()
   script.setUpdateDelta(12)
 
   self.damageThres = config.getParameter("damageThres") or 10
-  self.pixelAmount = config.getParameter("pixelAmount") or 2
-  self.pickupDelay = config.getParameter("pickupDelay") or 0.5
+  self.pixelAmount = config.getParameter("pixelAmount") or 1
+  self.pickupDelay = config.getParameter("pickupDelay") or 0
+  self.onMonster   = config.getParameter("onMonster")  -- default nil/false
 
   self.totalDmg = 0
+end
+
+function isEnemy(notif)
+  local selfTeam = entity.damageTeam()
+  local otherTeam = world.entityDamageTeam(notif.targetEntityId)
+  return otherTeam and selfTeam.team ~= otherTeam.team and otherTeam.type == "enemy" or false
 end
 
 function updateDamage(notifications)
   local lastN
   for _, n in pairs(notifications) do
-    if n.hitType == "Hit" then
-      self.totalDmg = self.totalDmg + n.damageDealt
+    if n.hitType == "Hit" and isEnemy(n) then
+      self.totalDmg = self.totalDmg + n.healthLost
       lastN = n
     end
   end
@@ -27,15 +53,19 @@ end
 function trigger(notif)
   local pixels = self.pixelAmount * math.floor(self.totalDmg / self.damageThres)
   self.totalDmg = math.floor(self.totalDmg % self.damageThres)
-  local pos = notif.position
-  local randVel = {-10 + math.random() * 20, math.random() * 15}
+
+  local monPos = notif.position
+  local randVel = self.pickupDelay > 0 and
+      {-10 + math.random() * 20, math.random() * 15} or
+      {0, 0}
+
   world.spawnItem(
       "money",
-      mcontroller.position(),
+      self.onMonster and monPos or mcontroller.position(),
       pixels,
       {},
       randVel,
-      0.5
+      self.pickupDelay
   )
 end
 

--- a/stats/effects/knightfall_augments/knightfall_pixelmaker.statuseffect
+++ b/stats/effects/knightfall_augments/knightfall_pixelmaker.statuseffect
@@ -4,7 +4,7 @@
   "effectConfig" : {
     "damageThres": 10,
     "pixelAmount": 1,
-    "pickupDelay": 0.5
+    "pickupDelay": 0
   },
   "defaultDuration" : 1,
 


### PR DESCRIPTION
 - Check if hit creature lost health and is an enemy
 - Add percentage mode to Lifesteal augment
 - Fixed Pixelmaker collection delay bug ( sorry oof ;~; )
 - Lifesteal has cooldown when equipped to prevent exploitation through re-equipping

(Also prefixed augment names (not item names) with `kf`)