### PR TITLE
Custom "shop" Category

### DIFF
--- a/items/categories.config.patch
+++ b/items/categories.config.patch
@@ -1,0 +1,14 @@
+[
+	[
+		{
+			"op": "test",
+			"path": "/labels/shop",
+			"inverse": true
+		},
+		{
+			"op": "add",
+			"path": "/labels/shop",
+			"value": "Shop"
+		}
+	]
+]

--- a/objects/crafting/knightfall_augmentedvendor/knightfall_augmentedvendor.object
+++ b/objects/crafting/knightfall_augmentedvendor/knightfall_augmentedvendor.object
@@ -2,7 +2,7 @@
   "objectName" : "knightfall_augmentedvendor",
   "colonyTags" : ["mechanical", "commerce"],
   "rarity" : "Legendary",
-  "category" : "other",
+  "category" : "shop",
   "price" : 7500,
   "printable" : false,
   "description" : "A vending machine that sells drone pods for Knightfall's augmented monsters.",

--- a/objects/crafting/knightfall_dronevendor/knightfall_dronevendor.object
+++ b/objects/crafting/knightfall_dronevendor/knightfall_dronevendor.object
@@ -2,7 +2,7 @@
   "objectName" : "knightfall_dronevendor",
   "colonyTags" : ["mechanical", "commerce"],
   "rarity" : "Legendary",
-  "category" : "other",
+  "category" : "shop",
   "price" : 7500,
   "printable" : false,
   "description" : "A vending machine that sells drone pods for different Knightfall drones.",

--- a/objects/crafting/knightfall_vehiclevendor/knightfall_vehiclevendor.object
+++ b/objects/crafting/knightfall_vehiclevendor/knightfall_vehiclevendor.object
@@ -2,7 +2,7 @@
   "objectName" : "knightfall_vehiclevendor",
   "colonyTags" : ["mechanical", "commerce"],
   "rarity" : "Legendary",
-  "category" : "other",
+  "category" : "shop",
   "price" : 15000,
   "printable" : false,
   "description" : "A vending machine that sells vehicle controllers for Knightfall's vehicles.",


### PR DESCRIPTION
Adds a custom category, "shop" and adds it to the three craftable shops. Custom category is patched in using a test patch, meaning if other mods add in the same, it will refrain from adding it to avoid conflicts. 