### PR TITLE
Fix Blockade inf armor causing issues with companions; revert 02017a9

### DIFF
--- a/stats/effects/knightfall_augments/blockade/blockade.lua
+++ b/stats/effects/knightfall_augments/blockade/blockade.lua
@@ -62,7 +62,7 @@ function update(dt)
       animator.setAnimationState("shield", "raise")
       animator.playSound("raise")
 
-      self.statGid = self.statGid or effect.addStatModifierGroup({{stat = "protection", amount = math.huge}, {stat = "grit", amount = 0.5}})
+      self.statGid = self.statGid or effect.addStatModifierGroup({{stat = "protection", amount = 100}, {stat = "grit", amount = 0.5}})
     end
     if not self.hidden and self.fadeTimer == 0 and animator.animationState("shield") == "raised" then
       self.fadeTimer = self.fadeTime

--- a/stats/effects/knightfall_augments/distributor/knightfall_distributor.lua
+++ b/stats/effects/knightfall_augments/distributor/knightfall_distributor.lua
@@ -65,8 +65,7 @@ end
 local function tryApplyEffects(entityId, effects)
   local oDamageTeam = world.entityDamageTeam(entityId)
   if not (oDamageTeam and oDamageTeam.team == entity.damageTeam().team or oDamageTeam.type == "friendly" or oDamageTeam.type == "assistant") then return end   -- if not same team
-  if world.entityCanDamage(entity.id(),entityId) then return end
- 
+
   for _, name in ipairs(effects) do    -- we don't need speed here so use ipairs :eyes:
     -- this or projectile? hmm
     world.sendEntityMessage(entityId, "applyStatusEffect", name, 4  --[[ < completely random ]], entity.id())


### PR DESCRIPTION
- The issues with companions dying are caused by other mods (unidentified) and Blockade applying infinite armor. It is now lowered to 100.
- Reverted 02017a9 since the original behavior is intentional.