### PR TITLE
Fixed a sprite offset issue on the small alarms.

### DIFF
--- a/objects/knightfall/alarms/knightfall_smallredalarm/knightfall_smallredalarm.object
+++ b/objects/knightfall/alarms/knightfall_smallredalarm/knightfall_smallredalarm.object
@@ -21,11 +21,11 @@
     {
       // PREVIEW ORIENTATION
       "image" : "knightfall_smallredalarmceiling.png:<color>.off",
-      "imagePosition" : [1, 0],
+      "imagePosition" : [0, 0],
       "animationParts" : {
         "alarm" : "knightfall_smallredalarmceiling.png"
       },
-      "animationPosition" : [1, 0],
+      "animationPosition" : [0, 0],
 
       "direction" : "left",
       "flipImages" : true,
@@ -37,11 +37,11 @@
     {
       // PREVIEW ORIENTATION
       "image" : "knightfall_smallredalarmceiling.png:<color>.off",
-      "imagePosition" : [1, 0],
+      "imagePosition" : [0, 0],
       "animationParts" : {
         "alarm" : "knightfall_smallredalarmceiling.png"
       },
-      "animationPosition" : [1, 0],
+      "animationPosition" : [0, 0],
 
       "direction" : "right",
 
@@ -108,11 +108,11 @@
 
     {
       "image" : "knightfall_smallredalarmceiling.png:<color>.off",
-      "imagePosition" : [1, 0],
+      "imagePosition" : [0, 0],
       "animationParts" : {
         "alarm" : "knightfall_smallredalarmceiling.png"
       },
-      "animationPosition" : [1, 0],
+      "animationPosition" : [0, 0],
 
       "direction" : "left",
       "flipImages" : true,
@@ -123,11 +123,11 @@
 
     {
       "image" : "knightfall_smallredalarmceiling.png:<color>.off",
-      "imagePosition" : [1, 0],
+      "imagePosition" : [0, 0],
       "animationParts" : {
         "alarm" : "knightfall_smallredalarmceiling.png"
       },
-      "animationPosition" : [1, 0],
+      "animationPosition" : [0, 0],
 
       "direction" : "right",
 
@@ -137,11 +137,11 @@
 
     {
       "image" : "knightfall_smallredalarmground.png:<color>.off",
-      "imagePosition" : [1, 0],
+      "imagePosition" : [0, 0],
       "animationParts" : {
         "alarm" : "knightfall_smallredalarmground.png"
       },
-      "animationPosition" : [1, 0],
+      "animationPosition" : [0, 0],
 
       "direction" : "left",
       "flipImages" : true,
@@ -152,11 +152,11 @@
 
     {
       "image" : "knightfall_smallredalarmground.png:<color>.off",
-      "imagePosition" : [1, 0],
+      "imagePosition" : [0, 0],
       "animationParts" : {
         "alarm" : "knightfall_smallredalarmground.png"
       },
-      "animationPosition" : [1, 0],
+      "animationPosition" : [0, 0],
 
       "direction" : "right",
 

--- a/objects/knightfall/alarms/knightfall_smallyellowalarm/knightfall_smallyellowalarm.object
+++ b/objects/knightfall/alarms/knightfall_smallyellowalarm/knightfall_smallyellowalarm.object
@@ -22,11 +22,11 @@
     {
       // PREVIEW ORIENTATION
       "image" : "knightfall_smallyellowalarmceiling.png:<color>.off",
-      "imagePosition" : [1, 0],
+      "imagePosition" : [0, 0],
       "animationParts" : {
         "alarm" : "knightfall_smallyellowalarmceiling.png"
       },
-      "animationPosition" : [1, 0],
+      "animationPosition" : [0, 0],
 
       "direction" : "left",
       "flipImages" : true,
@@ -38,11 +38,11 @@
     {
       // PREVIEW ORIENTATION
       "image" : "knightfall_smallyellowalarmceiling.png:<color>.off",
-      "imagePosition" : [1, 0],
+      "imagePosition" : [0, 0],
       "animationParts" : {
         "alarm" : "knightfall_smallyellowalarmceiling.png"
       },
-      "animationPosition" : [1, 0],
+      "animationPosition" : [0, 0],
 
       "direction" : "right",
 
@@ -109,11 +109,11 @@
 
     {
       "image" : "knightfall_smallyellowalarmceiling.png:<color>.off",
-      "imagePosition" : [1, 0],
+      "imagePosition" : [0, 0],
       "animationParts" : {
         "alarm" : "knightfall_smallyellowalarmceiling.png"
       },
-      "animationPosition" : [1, 0],
+      "animationPosition" : [0, 0],
 
       "direction" : "left",
       "flipImages" : true,
@@ -124,11 +124,11 @@
 
     {
       "image" : "knightfall_smallyellowalarmceiling.png:<color>.off",
-      "imagePosition" : [1, 0],
+      "imagePosition" : [0, 0],
       "animationParts" : {
         "alarm" : "knightfall_smallyellowalarmceiling.png"
       },
-      "animationPosition" : [1, 0],
+      "animationPosition" : [0, 0],
 
       "direction" : "right",
 
@@ -138,11 +138,11 @@
 
     {
       "image" : "knightfall_smallyellowalarmground.png:<color>.off",
-      "imagePosition" : [1, 0],
+      "imagePosition" : [0, 0],
       "animationParts" : {
         "alarm" : "knightfall_smallyellowalarmground.png"
       },
-      "animationPosition" : [1, 0],
+      "animationPosition" : [0, 0],
 
       "direction" : "left",
       "flipImages" : true,
@@ -153,11 +153,11 @@
 
     {
       "image" : "knightfall_smallyellowalarmground.png:<color>.off",
-      "imagePosition" : [1, 0],
+      "imagePosition" : [0, 0],
       "animationParts" : {
         "alarm" : "knightfall_smallyellowalarmground.png"
       },
-      "animationPosition" : [1, 0],
+      "animationPosition" : [0, 0],
 
       "direction" : "right",
 


### PR DESCRIPTION
Fixes a one-pixel offset that occurs for no reason, a carryover from a vanilla bug on the default Alarms.