### PR TITLE
bleed/corrosive status effect minor update

### DIFF
--- a/stats/effects/augmented_corrosiveacid/augmented_corrosiveacid.lua
+++ b/stats/effects/augmented_corrosiveacid/augmented_corrosiveacid.lua
@@ -1,4 +1,10 @@
 function init()
+  targetMaterialKind = status.statusProperty("targetMaterialKind")
+  damageMultiplier = 1.0
+  if not (targetMaterialKind == "robotic") then --reduce effect damage dealt by 50% if not robotic
+	damageMultiplier = 0.5
+  end
+  
   animator.setParticleEmitterOffsetRegion("drips", mcontroller.boundBox())
   animator.setParticleEmitterActive("drips", true)
   
@@ -19,7 +25,7 @@ function update(dt)
     self.tickTimer = self.tickTime
     status.applySelfDamageRequest({
       damageType = "IgnoresDef",
-      damage = math.floor(status.resourceMax("health") * self.tickDamagePercentage) + 1,
+      damage = damageMultiplier * (math.floor(status.resourceMax("health") * self.tickDamagePercentage) + 1),
       damageSourceKind = "poison",
       sourceEntityId = entity.id()
     })

--- a/stats/effects/knightfall_bleeding/knightfall_bleeding.lua
+++ b/stats/effects/knightfall_bleeding/knightfall_bleeding.lua
@@ -1,6 +1,16 @@
 function init()
-  animator.setParticleEmitterOffsetRegion("drips", mcontroller.boundBox())
-  animator.setParticleEmitterActive("drips", true)
+  targetMaterialKind = status.statusProperty("targetMaterialKind")
+  if (targetMaterialKind == "stone" or targetMaterialKind == "robotic") then
+	cancelDamage = true
+	effect.expire()
+  end
+  
+  if not cancelDamage then
+	animator.setParticleEmitterOffsetRegion("drips", mcontroller.boundBox())
+	animator.setParticleEmitterActive("drips", true)
+  else
+	animator.setParticleEmitterActive("drips", false)
+  end
   
   color = config.getParameter("color")
   
@@ -19,21 +29,25 @@ end
 function update(dt)
   tickTimer = math.max(0, tickTimer - dt)
   
-  if tickTimer == 0 and damageTaken <= maximumDamage then
-    tickTimer = tickTime
+  if not cancelDamage then
+	if tickTimer == 0 and damageTaken <= maximumDamage then
+		tickTimer = tickTime
      
-    local damage = math.max(math.ceil(status.resourceMax("health") * tickDamagePercentage), minimumTickDamage)
-    damageTaken = damageTaken + damage
+		local damage = math.max(math.ceil(status.resourceMax("health") * tickDamagePercentage), minimumTickDamage)
+		damageTaken = damageTaken + damage
      
-    status.applySelfDamageRequest({
-      damageType = "IgnoresDef",
-      damage = damage,
-      damageSourceKind = damageSourceKind,
-      sourceEntityId = entity.id()
-    })
+		status.applySelfDamageRequest({
+			damageType = "IgnoresDef",
+			damage = damage,
+			damageSourceKind = damageSourceKind,
+			sourceEntityId = entity.id()
+		})
     
-    tickDamagePercentage = math.max(0, math.min(maximumTickDamagePercentage, tickDamagePercentage + tickDamageIncrement))
-  end
+		tickDamagePercentage = math.max(0, math.min(maximumTickDamagePercentage, tickDamagePercentage + tickDamageIncrement))
+	end
   
-  effect.setParentDirectives(string.format("fade=%s=%.1f", color, (tickTimer / tickTime) * 0.8))
+	effect.setParentDirectives(string.format("fade=%s=%.1f", color, (tickTimer / tickTime) * 0.8))
+  else
+	animator.setParticleEmitterActive("drips", false)
+  end
 end


### PR DESCRIPTION
updated knightfall's bleed status effects to be automatically self-nullifying if entity is of targetMaterialType "stone" or "robotic", and the augmented's corrosive acid status effects deals 50% less damage when applied to anything not explicitly robotic.