### PR TITLE
Fixed Augment Crash

### DIFF
--- a/items/knightfall/augments/back/knightfall_augmentedsupport_augment.augment
+++ b/items/knightfall/augments/back/knightfall_augmentedsupport_augment.augment
@@ -3,7 +3,7 @@
   "price" : 6500, 
   "rarity" : "Legendary",  
   "rarityLabelKind" : "knightfall",
-  "tooltipKind" : "knightfall_augment",
+  "tooltipKind" : "eppaugment",
   "category" : "eppAugment",
   "inventoryIcon" : "knightfall_augmentedsupport_augment.png",
   "description" : "If your health drops to 35% or less, gain +2 armor. Augmented monsters are teleported to you, and these monsters last for 10s before they disappear.",

--- a/items/knightfall/augments/back/knightfall_berserker_augment.augment
+++ b/items/knightfall/augments/back/knightfall_berserker_augment.augment
@@ -3,7 +3,7 @@
   "price" : 5000, 
   "rarity" : "Rare",  
   "rarityLabelKind" : "knightfall",
-  "tooltipKind" : "knightfall_augment",
+  "tooltipKind" : "eppaugment",
   "category" : "eppAugment",
   "inventoryIcon" : "knightfall_berserker_augment.png",
   "description" : "If your health drops to 35% or less, gain +2 armor, and +100% more damage that lasts for 10s.",

--- a/items/knightfall/augments/back/knightfall_blockade_augment.augment
+++ b/items/knightfall/augments/back/knightfall_blockade_augment.augment
@@ -3,7 +3,7 @@
   "price" : 9500,  // change
   "rarity" : "Essential",   // change?
   "rarityLabelKind" : "knightfall",
-  "tooltipKind" : "knightfall_augment",
+  "tooltipKind" : "eppaugment",
   "category" : "eppAugment",
   "inventoryIcon" : "knightfall_blockade_augment.png",
   "description" : "Gain a shield that blocks incoming damage. If the shield receives damage, it will linger for 1s before disappearing. Recharges after 10s of not receiving any damage.",

--- a/items/knightfall/augments/back/knightfall_distributor_augment.augment
+++ b/items/knightfall/augments/back/knightfall_distributor_augment.augment
@@ -3,7 +3,7 @@
   "price" : 12000,   
   "rarity" : "Essential",  
   "rarityLabelKind" : "knightfall",
-  "tooltipKind" : "knightfall_augment",
+  "tooltipKind" : "eppaugment",
   "category" : "eppAugment",
   "inventoryIcon" : "knightfall_distributor_augment.png",
   "description" : "Distributes another augment's effects over a 15 block radius towards your allies. By itself, this augment doesn't do anything. You will need another augment in order to fully utilize this augment.",   

--- a/items/knightfall/augments/back/knightfall_dronesupport_augment.augment
+++ b/items/knightfall/augments/back/knightfall_dronesupport_augment.augment
@@ -3,7 +3,7 @@
   "price" : 6500,   
   "rarity" : "Legendary",  
   "rarityLabelKind" : "knightfall",
-  "tooltipKind" : "knightfall_augment",
+  "tooltipKind" : "eppaugment",
   "category" : "eppAugment",
   "inventoryIcon" : "knightfall_dronesupport_augment.png",
   "description" : "If your health drops to 35% or less, gain +2 armor. Spectre drones are teleported to you, and these drones last for 10s before they self-destruct.", 

--- a/items/knightfall/augments/back/knightfall_irradiator_augment.augment
+++ b/items/knightfall/augments/back/knightfall_irradiator_augment.augment
@@ -3,7 +3,7 @@
   "price" : 4500,
   "rarity" : "Rare",
   "rarityLabelKind" : "knightfall",
-  "tooltipKind" : "knightfall_augment",
+  "tooltipKind" : "eppaugment",
   "category" : "eppAugment",
   "inventoryIcon" : "knightfall_irradiator_augment.png",
   "description" : "Augments all your attacks with poison damage.",

--- a/items/knightfall/augments/back/knightfall_lifesteal_augment.augment
+++ b/items/knightfall/augments/back/knightfall_lifesteal_augment.augment
@@ -3,7 +3,7 @@
   "price" : 7500,
   "rarity" : "Legendary",
   "rarityLabelKind" : "knightfall",
-  "tooltipKind" : "knightfall_augment",
+  "tooltipKind" : "eppaugment",
   "category" : "eppAugment",
   "inventoryIcon" : "knightfall_lifesteal_augment.png",
   "description" : "Your attacks heal you for 15% of the damage dealt. Has a 1s cooldown in-between heals.",

--- a/items/knightfall/augments/back/knightfall_metalthorns_augment.augment
+++ b/items/knightfall/augments/back/knightfall_metalthorns_augment.augment
@@ -3,7 +3,7 @@
   "price" : 8000,
   "rarity" : "Rare",
   "rarityLabelKind" : "knightfall",
-  "tooltipKind" : "knightfall_augment",
+  "tooltipKind" : "eppaugment",
   "category" : "eppAugment",
   "inventoryIcon" : "knightfall_metalthorns_augment.png",
   "description" : "A stronger version of the Thorns Augment. Deals 2x more damage.",

--- a/items/knightfall/augments/back/knightfall_pixelmaker_augment.augment
+++ b/items/knightfall/augments/back/knightfall_pixelmaker_augment.augment
@@ -3,7 +3,7 @@
   "price" : 7500,
   "rarity" : "Legendary",
   "rarityLabelKind" : "knightfall",
-  "tooltipKind" : "knightfall_augment",
+  "tooltipKind" : "eppaugment",
   "category" : "eppAugment",
   "inventoryIcon" : "knightfall_pixelmaker_augment.png",
   "description" : "Rewards you with +2 pixels for every 10 damage you deal.",

--- a/items/knightfall/augments/back/knightfall_recharger_augment.augment
+++ b/items/knightfall/augments/back/knightfall_recharger_augment.augment
@@ -3,7 +3,7 @@
   "price" : 7500, 
   "rarity" : "Legendary", 
   "rarityLabelKind" : "knightfall",
-  "tooltipKind" : "knightfall_augment",
+  "tooltipKind" : "eppaugment",
   "category" : "eppAugment",
   "inventoryIcon" : "knightfall_recharger_augment.png",
   "description" : "Halves your total energy. Attacking enemies recovers 7.5% of your energy, refreshing every 1s. Killing enemies recovers 20% of your energy instead.",  


### PR DESCRIPTION
reverted tooltip back to eppaugment to prevent them from crashing when selected.